### PR TITLE
Fix embedded Discord.Net.Webhook resource target path

### DIFF
--- a/WindowsGSM/WindowsGSM.csproj
+++ b/WindowsGSM/WindowsGSM.csproj
@@ -741,7 +741,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\packages\Discord.Net.Webhook.2.2.0\lib\netstandard2.1\Discord.Net.Webhook.dll">
+    <EmbeddedResource Include="..\packages\Discord.Net.Webhook.2.2.0\lib\netstandard2.0\Discord.Net.Webhook.dll">
       <Link>ReferencesEx\Discord.Net.Webhook.dll</Link>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- update the embedded Discord.Net.Webhook resource to use the netstandard2.0 build that matches .NET Framework 4.7.2

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_690cbc9cffb88321be151e5471b34026