### PR TITLE
Fix Discord bot command parsing warnings

### DIFF
--- a/WindowsGSM/DiscordBot/Commands.cs
+++ b/WindowsGSM/DiscordBot/Commands.cs
@@ -123,7 +123,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_Start(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length == 2 && int.TryParse(args[1], out int i))
+            if (args.Length == 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {
@@ -162,7 +162,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_Stop(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length == 2 && int.TryParse(args[1], out int i))
+            if (args.Length == 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {
@@ -201,7 +201,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_Restart(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length == 2 && int.TryParse(args[1], out int i))
+            if (args.Length == 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {
@@ -236,7 +236,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_SendCommand(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length >= 2 && int.TryParse(args[1], out int i))
+            if (args.Length >= 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {
@@ -270,7 +270,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_Backup(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length >= 2 && int.TryParse(args[1], out int i))
+            if (args.Length >= 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {
@@ -308,7 +308,7 @@ namespace WindowsGSM.DiscordBot
         private async Task Action_Update(SocketMessage message, string command)
         {
             string[] args = command.Split(' ');
-            if (args.Length >= 2 && int.TryParse(args[1], out int i))
+            if (args.Length >= 2 && int.TryParse(args[1], out _))
             {
                 await Application.Current.Dispatcher.Invoke(async () =>
                 {


### PR DESCRIPTION
## Summary
- replace unused out variables with discards in Discord bot command handlers to silence CS0219 warnings

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690cc7ed15b0832182e55cf2b0a799a7