### PR TITLE
Silence nullable warnings from external packages

### DIFF
--- a/WindowsGSM/WindowsGSM.csproj
+++ b/WindowsGSM/WindowsGSM.csproj
@@ -48,7 +48,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1998;</NoWarn>
+    <NoWarn>1998;CS8632</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -63,7 +63,7 @@
     <DocumentationFile>
     </DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
-    <NoWarn>1998;</NoWarn>
+    <NoWarn>1998;CS8632</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Images\WindowsGSM.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary
- add CS8632 to the NoWarn list so builds ignore nullable annotations coming from third-party packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690cc99bdef083219dbf20cb01ddff6b